### PR TITLE
Add MapFailureStrategy option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,11 @@ jobs:
         with:
           java-version: 21
           distribution: zulu
+          cache: maven
 
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v1.1.1
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: "projects/848539402404/locations/global/workloadIdentityPools/gh-actions/providers/gh-actions"
           service_account: "gh-actions-dapla-pseudo@artifact-registry-5n.iam.gserviceaccount.com"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v1.1.1
         with:
           workload_identity_provider: "projects/848539402404/locations/global/workloadIdentityPools/gh-actions/providers/gh-actions"
           service_account: "gh-actions-dapla-pseudo@artifact-registry-5n.iam.gserviceaccount.com"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,8 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    #runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,7 @@ on:
 
 jobs:
   build:
-    #runs-on: ubuntu-latest
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write

--- a/src/main/java/no/ssb/dapla/dlp/pseudo/func/composite/MapAndEncryptFunc.java
+++ b/src/main/java/no/ssb/dapla/dlp/pseudo/func/composite/MapAndEncryptFunc.java
@@ -86,6 +86,9 @@ public class MapAndEncryptFunc extends AbstractPseudoFunc {
                                        Function<PseudoFuncInput, PseudoFuncOutput> inner,
                                        Function<PseudoFuncInput, PseudoFuncOutput> outer) {
         final PseudoFuncOutput innerOutput = inner.apply(input);
+        if (innerOutput.getValue() == null) {
+            return innerOutput;
+        }
         final PseudoFuncOutput outerOutput = outer.apply(
                 PseudoFuncInput.of(innerOutput.getValue()));
         innerOutput.getWarnings().forEach(outerOutput::addWarning);

--- a/src/main/java/no/ssb/dapla/dlp/pseudo/func/map/MapFailureStrategy.java
+++ b/src/main/java/no/ssb/dapla/dlp/pseudo/func/map/MapFailureStrategy.java
@@ -1,0 +1,6 @@
+package no.ssb.dapla.dlp.pseudo.func.map;
+
+public enum MapFailureStrategy {
+    RETURN_NULL,
+    RETURN_ORIGINAL
+}

--- a/src/main/java/no/ssb/dapla/dlp/pseudo/func/map/MapFuncConfig.java
+++ b/src/main/java/no/ssb/dapla/dlp/pseudo/func/map/MapFuncConfig.java
@@ -9,10 +9,12 @@ import lombok.experimental.UtilityClass;
 public class MapFuncConfig {
     private final String context;
     private final String snapshotDate;
+    private final MapFailureStrategy mapFailureStrategy;
 
     @UtilityClass
     public static class Param {
         public static final String CONTEXT = "context";
         public static final String SNAPSHOT_DATE = "snapshotDate";
+        public static final String MAP_FAILURE_STRATEGY = "failureStrategy";
     }
 }

--- a/src/main/java/no/ssb/dapla/dlp/pseudo/func/map/MapFuncConfigService.java
+++ b/src/main/java/no/ssb/dapla/dlp/pseudo/func/map/MapFuncConfigService.java
@@ -1,5 +1,7 @@
 package no.ssb.dapla.dlp.pseudo.func.map;
 import no.ssb.dapla.dlp.pseudo.func.PseudoFuncConfig;
+
+import static no.ssb.dapla.dlp.pseudo.func.map.MapFuncConfig.Param.MAP_FAILURE_STRATEGY;
 import static no.ssb.dapla.dlp.pseudo.func.map.MapFuncConfig.Param.SNAPSHOT_DATE;
 
 public class MapFuncConfigService {
@@ -8,6 +10,8 @@ public class MapFuncConfigService {
 
         return MapFuncConfig.builder()
                 .snapshotDate(genericConfig.get(SNAPSHOT_DATE, String.class).orElse(null))
+                .mapFailureStrategy(genericConfig.get(MAP_FAILURE_STRATEGY, MapFailureStrategy.class)
+                        .orElse(MapFailureStrategy.RETURN_ORIGINAL))
                 .context(context)
                 .build();
     }

--- a/src/main/java/no/ssb/dapla/dlp/pseudo/func/map/Mapper.java
+++ b/src/main/java/no/ssb/dapla/dlp/pseudo/func/map/Mapper.java
@@ -9,8 +9,8 @@ public interface Mapper {
 
     void init(PseudoFuncInput data);
     void setConfig(Map<String, Object> config);
-    PseudoFuncOutput map(PseudoFuncInput data) throws MappingNotFoundException;
+    PseudoFuncOutput map(PseudoFuncInput data);
 
-    PseudoFuncOutput restore(PseudoFuncInput mapped) throws MappingNotFoundException;
+    PseudoFuncOutput restore(PseudoFuncInput mapped);
 
 }

--- a/src/main/java/no/ssb/dapla/dlp/pseudo/func/map/MappingNotFoundException.java
+++ b/src/main/java/no/ssb/dapla/dlp/pseudo/func/map/MappingNotFoundException.java
@@ -1,7 +1,0 @@
-package no.ssb.dapla.dlp.pseudo.func.map;
-
-public class MappingNotFoundException extends RuntimeException {
-    public MappingNotFoundException(String message) {
-        super(message);
-    }
-}

--- a/src/test/java/no/ssb/dapla/dlp/pseudo/func/composite/MapAndEncryptFuncTest.java
+++ b/src/test/java/no/ssb/dapla/dlp/pseudo/func/composite/MapAndEncryptFuncTest.java
@@ -8,8 +8,9 @@ import no.ssb.dapla.dlp.pseudo.func.PseudoFuncInput;
 import no.ssb.dapla.dlp.pseudo.func.PseudoFuncOutput;
 import no.ssb.dapla.dlp.pseudo.func.fpe.FpeFunc;
 import no.ssb.dapla.dlp.pseudo.func.fpe.FpeFuncConfig;
+import no.ssb.dapla.dlp.pseudo.func.map.MapFailureStrategy;
 import no.ssb.dapla.dlp.pseudo.func.map.MapFunc;
-import no.ssb.dapla.dlp.pseudo.func.map.MappingNotFoundException;
+import no.ssb.dapla.dlp.pseudo.func.map.MapFuncConfig;
 import no.ssb.dapla.dlp.pseudo.func.map.TestMapper;
 import org.junit.jupiter.api.Test;
 
@@ -19,16 +20,17 @@ import static org.junit.jupiter.api.Assertions.*;
 public class MapAndEncryptFuncTest {
     private static final String BASE64_ENCODED_KEY = "w0/G6A5e/KHtTo31FD6mhhS1Tkga43l79IBK24gM4F8=";
 
-    final PseudoFuncConfig config = new PseudoFuncConfig(ImmutableMap.of(
-            PseudoFuncConfig.Param.FUNC_DECL, "map-fpe-test",
-            PseudoFuncConfig.Param.FUNC_IMPL, MapAndEncryptFunc.class.getName(),
-            MapAndEncryptFuncConfig.Param.MAP_FUNC_IMPL, MapFunc.class.getName(),
-            MapAndEncryptFuncConfig.Param.ENCRYPTION_FUNC_IMPL, FpeFunc.class.getName(),
-            FpeFuncConfig.Param.ALPHABET, "alphanumeric+whitespace",
-            FpeFuncConfig.Param.KEY_ID, "keyId1",
-            FpeFuncConfig.Param.KEY_DATA, BASE64_ENCODED_KEY
-
-    ));
+    private PseudoFuncConfig getConfig() {
+        return new PseudoFuncConfig(ImmutableMap.of(
+                PseudoFuncConfig.Param.FUNC_DECL, "map-fpe-test",
+                PseudoFuncConfig.Param.FUNC_IMPL, MapAndEncryptFunc.class.getName(),
+                MapAndEncryptFuncConfig.Param.MAP_FUNC_IMPL, MapFunc.class.getName(),
+                MapAndEncryptFuncConfig.Param.ENCRYPTION_FUNC_IMPL, FpeFunc.class.getName(),
+                FpeFuncConfig.Param.ALPHABET, "alphanumeric+whitespace",
+                FpeFuncConfig.Param.KEY_ID, "keyId1",
+                FpeFuncConfig.Param.KEY_DATA, BASE64_ENCODED_KEY
+        ));
+    }
     /*
      * This test should transform OriginalValue -> MappedValue -> FPE encrypted MappedValue
      * (and back)
@@ -36,7 +38,7 @@ public class MapAndEncryptFuncTest {
     @Test
     public void transformAndRestore() {
         String expectedVal = "ygd1M9at1nK"; // FPE encrypted MappedValue
-        PseudoFunc func = PseudoFuncFactory.create(config);
+        PseudoFunc func = PseudoFuncFactory.create(getConfig());
 
         PseudoFuncOutput pseudonymized = func.apply(PseudoFuncInput.of(TestMapper.ORIGINAL));
         assertThat(pseudonymized.getValue()).isEqualTo(expectedVal);
@@ -46,21 +48,40 @@ public class MapAndEncryptFuncTest {
     }
 
     @Test
-    public void call_apply_with_mapping_failure() {
+    public void transformAndRestoreWithMissingStrategyIgnore() {
+        // Using MapFailureStrategy.IGNORE one can successfully map and encrypt "gibberish"
+        // and get the same decrypted result back - although the Mapper function didn't find
+        // a mapping for "gibberish"
+        String originalVal = "gibberish";
+        String expectedVal = "J0LjYPO9f"; // FPE encrypted originalVal
+        final PseudoFuncConfig config = getConfig();
+        config.add(MapFuncConfig.Param.MAP_FAILURE_STRATEGY, MapFailureStrategy.RETURN_ORIGINAL);
         PseudoFunc func = PseudoFuncFactory.create(config);
 
-        assertThrows(MappingNotFoundException.class,() ->
-            func.apply(PseudoFuncInput.of("unknown"))
-        );
+        PseudoFuncOutput pseudonymized = func.apply(PseudoFuncInput.of(originalVal));
+        assertThat(pseudonymized.getValue()).isEqualTo(expectedVal);
+
+        PseudoFuncOutput depseudonymized = func.restore(PseudoFuncInput.of(pseudonymized.getValue()));
+        assertThat(depseudonymized.getValue()).isEqualTo(originalVal);
+    }
+
+
+    @Test
+    public void call_apply_with_mapping_failure() {
+        final PseudoFuncConfig config = getConfig();
+        config.add(MapFuncConfig.Param.MAP_FAILURE_STRATEGY, MapFailureStrategy.RETURN_NULL);
+        PseudoFunc func = PseudoFuncFactory.create(config);
+
+        assertThat(func.apply(PseudoFuncInput.of("unknown")).getValue()).isNull();
     }
 
     @Test
     public void call_restore_with_mapping_failure() {
+        final PseudoFuncConfig config = getConfig();
+        config.add(MapFuncConfig.Param.MAP_FAILURE_STRATEGY, MapFailureStrategy.RETURN_NULL);
         PseudoFunc func = PseudoFuncFactory.create(config);
 
-        assertThrows(MappingNotFoundException.class,() ->
-                func.restore(PseudoFuncInput.of("unknown"))
-        );
+        assertThat(func.restore(PseudoFuncInput.of("unknown")).getValue()).isNull();
     }
 
 }

--- a/src/test/java/no/ssb/dapla/dlp/pseudo/func/map/MapFuncTest.java
+++ b/src/test/java/no/ssb/dapla/dlp/pseudo/func/map/MapFuncTest.java
@@ -26,4 +26,28 @@ public class MapFuncTest {
         assertThat(depseudonymized.getValue()).isEqualTo(TestMapper.ORIGINAL);
     }
 
+    @Test
+    public void testInvalidMappingStrategyIgnore() {
+        final PseudoFuncConfig config = new PseudoFuncConfig(ImmutableMap.of(
+                PseudoFuncConfig.Param.FUNC_DECL, "map-test",
+                PseudoFuncConfig.Param.FUNC_IMPL, MapFunc.class.getName(),
+                MapFuncConfig.Param.MAP_FAILURE_STRATEGY, MapFailureStrategy.RETURN_ORIGINAL
+        ));
+        PseudoFunc func = PseudoFuncFactory.create(config);
+
+        PseudoFuncOutput mapOutput = func.apply(PseudoFuncInput.of("nomappingavailable"));
+        assertThat(mapOutput.getValue()).isEqualTo("nomappingavailable");
+    }
+
+    @Test
+    public void testInvalidMappingStrategyAbort() {
+        final PseudoFuncConfig config = new PseudoFuncConfig(ImmutableMap.of(
+                PseudoFuncConfig.Param.FUNC_DECL, "map-test",
+                PseudoFuncConfig.Param.FUNC_IMPL, MapFunc.class.getName(),
+                MapFuncConfig.Param.MAP_FAILURE_STRATEGY, MapFailureStrategy.RETURN_NULL
+        ));
+        PseudoFunc func = PseudoFuncFactory.create(config);
+
+        assertThat(func.apply(PseudoFuncInput.of("unknown")).getValue()).isNull();
+    }
 }


### PR DESCRIPTION
The `MapFailureStrategy` option will control the behaviour of `MapFunc` and `MapAndEncryptFunc`. The change will also influence classes that implements the `Mapper` interface. 

The `MappingNotFoundException` is removed from the `Mapper` interface since it should no longer be used for handling mapping failures.